### PR TITLE
Fix handler visibility update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -159,23 +159,26 @@ watch(world.trigger, newV => {
   drawShapes();
 });
 
+watch(world.enableHandler, () => {
+  drawShapes();
+});
+
 function drawShapes() {
   const canvas = _OriginalCanvas.value;
-  if (!canvas || !world.CanvasShapes.value) return;
+  if (!canvas || !world.DrawingShapes.value) return;
 
   const ctx = canvas.getContext("2d");
   const shapeDrawer = ShapeDrawer.from(world).using(ctx);
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  const withoutHandlerShapes = world.CanvasShapes.value.filter( (shape) => shape.role !== "handler" );
-  for (const shape of withoutHandlerShapes) { 
-    shapeDrawer.path(shape);
+  for (const shape of world.DrawingShapes.value) {
+    if (shape.role === "handler") {
+      shapeDrawer.handler(shape);
+    } else {
+      shapeDrawer.path(shape);
+    }
   }
-
-  if (!world.enableHandler) return;
-  const handlers = world.CanvasShapes.value.filter( (shape) => shape.role === "handler" );
-  handlers.forEach((handler) => shapeDrawer.handler(handler));
 }
 </script>
 

--- a/src/stores/CanvasWorld2D.js
+++ b/src/stores/CanvasWorld2D.js
@@ -8,6 +8,10 @@ export function useCanvasWorld2D() {
   const CanvasShapes = ref([]);
 
   const enableHandler = ref(false);
+  const DrawingShapes = computed(() => {
+    if (enableHandler.value) return CanvasShapes.value;
+    return CanvasShapes.value.filter(shape => shape.role !== 'handler');
+  });
   const handlerHitSize = ref(10);
 
   const trigger = ref(0);
@@ -132,6 +136,7 @@ export function useCanvasWorld2D() {
   return {
     VertexTrackingSheet,
     CanvasShapes,
+    DrawingShapes,
     getPosition,
     addShape,
     addHandler,


### PR DESCRIPTION
## Summary
- watch `enableHandler` to refresh shapes when handler visibility changes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6b5973b883308ebaa1f107dd2a3b